### PR TITLE
Fix TRPC-Provider port mismatch

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,4 @@
 DATABASE_URL=postgres://username:password@host:port/database
-SERVER_URL=http://host:port
 AUTH_SECRET=secret
 USERPASS_SALT_ROUNDS=12
 ADMIN_EMAIL=example@mail.com

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -7,11 +7,6 @@ declare global {
 			DATABASE_URL: string;
 
 			/**
-			 * Server URL for the Client
-			 */
-			SERVER_URL: string;
-
-			/**
 			 * Required by Next-Auth (see https://authjs.dev/getting-started/installation)
 			 */
 			AUTH_SECRET: string;

--- a/src/lib/trpc-provider.tsx
+++ b/src/lib/trpc-provider.tsx
@@ -5,13 +5,30 @@ import { httpBatchLink } from "@trpc/client";
 import React, { useState } from "react";
 import { trpc } from "./trpc-client";
 
+/**
+ * https://trpc.io/docs/client/nextjs/setup
+ */
+function getBaseUrl() {
+	if (typeof window !== "undefined")
+		// browser should use relative path
+		return "";
+	if (process.env.VERCEL_URL)
+		// reference for vercel.com
+		return `https://${process.env.VERCEL_URL}`;
+	if (process.env.RENDER_INTERNAL_HOSTNAME)
+		// reference for render.com
+		return `http://${process.env.RENDER_INTERNAL_HOSTNAME}:${process.env.PORT}`;
+	// assume localhost
+	return `http://localhost:${process.env.PORT ?? 3001}`;
+}
+
 export default function TRPCProvider({ children }: { children: React.ReactNode }) {
 	const [queryClient] = useState(() => new QueryClient({}));
 	const [trpcClient] = useState(() =>
 		trpc.createClient({
 			links: [
 				httpBatchLink({
-					url: "http://localhost:3000/api/trpc",
+					url: `${getBaseUrl()}/api/trpc`,
 				}),
 			],
 		}),


### PR DESCRIPTION
Previously, the NextJS default port was changed from 3000 to 3001. 

This PR reimplements the base URL for TRPC-Provider by dynamically checking the base URL instead of a hardcoded string. The `SERVER_URL` environment variable has also been removed.